### PR TITLE
Add support for async pushes to index using REST API

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -82,9 +82,16 @@
     <echo taskname="check-ivy" message="${ivy.version-message}"/>
     <ivy:cachepath pathid="path.build" conf="build" log="${ivy.logging}"/>
     <ivy:cachepath pathid="path.bundle" conf="bundle" log="${ivy.logging}"/>
+    <ivy:cachepath pathid="path.addons" conf="addons" log="${ivy.logging}"/>
     <!--<ivy:cachepath pathid="path.test" conf="test" log="${ivy.logging}"/>-->
     <path id="path.run">
       <path refid="path.bundle"/>
+      <pathelement path="build"/>
+      <fileset dir="${plib}" includes="*.jar"/>
+    </path>
+    <path id="path.push-server.run">
+      <path refid="path.bundle"/>
+      <path refid="path.addons"/>
       <pathelement path="build"/>
       <fileset dir="${plib}" includes="*.jar"/>
     </path>
@@ -151,6 +158,13 @@
        <sysproperty key="log4j.configurationFile" value="${log4j-conf}"/>
        <arg file="conf/config.xml"/>
        <arg value="${index}"/>
+    </java>
+  </target>
+
+  <target name="run-push-server" depends="compile">
+    <java fork="true" dir="." classname="de.pangaea.metadataportal.push.PushServer" classpathref="path.push-server.run">
+       <sysproperty key="log4j.configurationFile" value="${log4j-conf}"/>
+       <arg file="conf/config.xml"/>
     </java>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -183,16 +183,24 @@
   <!-- PACKAGING -->
   <target name="binpackage" depends="dist,javadocs">
     <ivy:cachefileset setid="fileset.bundle" conf="bundle" log="${ivy.logging}"/>
+    <ivy:cachefileset setid="fileset.addons" conf="addons" log="${ivy.logging}"/>
     <zip destfile="${basedir}/${pkgname}-bin.zip">
       <mappedresources>
         <fileset refid="fileset.bundle"/>
         <chainedmapper>
           <flattenmapper/>
-          <globmapper from="*" to="${pkgname}/lib/*"/>
+          <globmapper from="*" to="${pkgname}/lib/core/*"/>
         </chainedmapper>
       </mappedresources>
-      <zipfileset dir="${dist}" prefix="${pkgname}/lib"/>
-      <zipfileset dir="${plib}" prefix="${pkgname}/lib"/>
+      <mappedresources>
+        <fileset refid="fileset.addons"/>
+        <chainedmapper>
+          <flattenmapper/>
+          <globmapper from="*" to="${pkgname}/lib/addons/*"/>
+        </chainedmapper>
+      </mappedresources>
+      <zipfileset dir="${dist}" prefix="${pkgname}/lib/core"/>
+      <zipfileset dir="${plib}" prefix="${pkgname}/lib/core"/>
       <zipfileset dir="${plugins}" prefix="${pkgname}/plugins"/>
       <zipfileset dir="${basedir}/conf" prefix="${pkgname}/conf"/>
       <zipfileset dir="${basedir}/scripts" prefix="${pkgname}/scripts"/>

--- a/conf/config.xml
+++ b/conf/config.xml
@@ -21,7 +21,7 @@
 			<!-- we want to remove all documents harvested with harvester 'pangaea-carboocean' that are from project 'JGOFS' -->
 			<cfg:deny>$dp:harvesterIdentifier='pangaea-carboocean' and /dif:DIF/dif:Project/dif:Short_Name[contains(.,'JGOFS')]</cfg:deny>
 			<!-- we want to remove all documents with wrong namespace -->
-			<!--<cfg:deny>namespace-uri(/*)!='http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/'</cfg:deny>-->
+			<cfg:deny>namespace-uri(/*)!='http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/'</cfg:deny>
 		</cfg:filters>
 		<!--
 			Field definitions:

--- a/conf/config.xml
+++ b/conf/config.xml
@@ -21,7 +21,7 @@
 			<!-- we want to remove all documents harvested with harvester 'pangaea-carboocean' that are from project 'JGOFS' -->
 			<cfg:deny>$dp:harvesterIdentifier='pangaea-carboocean' and /dif:DIF/dif:Project/dif:Short_Name[contains(.,'JGOFS')]</cfg:deny>
 			<!-- we want to remove all documents with wrong namespace -->
-			<cfg:deny>namespace-uri(/*)!='http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/'</cfg:deny>
+			<!--<cfg:deny>namespace-uri(/*)!='http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/'</cfg:deny>-->
 		</cfg:filters>
 		<!--
 			Field definitions:

--- a/ivy.xml
+++ b/ivy.xml
@@ -4,10 +4,12 @@
   <configurations>
      <conf name="build" transitive="true" visibility="private" />
      <conf name="bundle" transitive="true" visibility="private" />
+     <conf name="addons" transitive="true" visibility="private" />
      <conf name="buildtools" transitive="true" visibility="private" />
   </configurations>
   <dependencies>
-    <dependency org="org.elasticsearch.client" name="transport" rev="5.6.16" conf="build,bundle->default"/>
+    <dependency org="org.elasticsearch" name="elasticsearch" rev="5.6.16" conf="build,bundle->default"/>
+    <dependency org="org.elasticsearch.plugin" name="transport-netty4-client" rev="5.6.16" conf="build,bundle->default"/>
 
     <dependency org="commons-logging" name="commons-logging" rev="1.2" conf="build,bundle->default"/>
     <dependency org="commons-digester" name="commons-digester" rev="2.1" conf="build,bundle->default"/>
@@ -19,6 +21,9 @@
     <dependency org="org.apache.logging.log4j" name="log4j-jcl" rev="2.13.3"  conf="build,bundle->default"/>
     
     <dependency org="net.sourceforge.nekohtml" name="nekohtml" rev="1.9.22" conf="bundle->default"/>
+    
+    <!-- HTTP server to accept document pushes: -->
+    <dependency org="io.undertow" name="undertow-core" rev="1.4.28.Final" conf="build,addons->default"/>
     
     <!-- build tools: -->
     <dependency org="de.thetaphi" name="forbiddenapis" rev="3.1" conf="buildtools->default"/>

--- a/scripts/classpath.cmd
+++ b/scripts/classpath.cmd
@@ -1,6 +1,6 @@
 @echo off
 SET CLASSPATH=
-FOR %%i IN (..\lib\*.jar ..\plugins\*.jar ..\dist\*.jar) DO CALL :addPart %%i
+FOR %%i IN (..\lib\core\*.jar ..\lib\addons\*.jar ..\plugins\*.jar ..\dist\*.jar) DO CALL :addPart %%i
 GOTO :eof
 
 :addPart

--- a/scripts/classpath.sh
+++ b/scripts/classpath.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 CLASSPATH=
-for i in ../lib/*.jar ../plugins/*.jar ../dist/*.jar; do
+for i in ../lib/core/*.jar ../lib/addons/*.jar ../plugins/*.jar ../dist/*.jar; do
 	CLASSPATH="$CLASSPATH:$i"
 done
 if [ -x /usr/bin/cygpath ]; then

--- a/scripts/push-service.cmd
+++ b/scripts/push-service.cmd
@@ -1,0 +1,4 @@
+@echo off
+CALL config.cmd
+CALL classpath.cmd
+java %PANFMP_TOOLS_JAVA_OPTIONS% -Dlog4j.configurationFile=%PANFMP_TOOLS_LOG4J_CONFIG% de.pangaea.metadataportal.push.PushServer %PANFMP_CONFIG%

--- a/scripts/push-service.sh
+++ b/scripts/push-service.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+cd `dirname $0`
+. ./config.sh
+. ./classpath.sh
+exec java ${PANFMP_TOOLS_JAVA_OPTIONS} \
+	-Dlog4j.configurationFile="${PANFMP_TOOLS_LOG4J_CONFIG}" \
+	de.pangaea.metadataportal.push.PushServer \
+	"${PANFMP_CONFIG}" "$@"

--- a/src/de/pangaea/metadataportal/harvester/ElasticsearchHarvester.java
+++ b/src/de/pangaea/metadataportal/harvester/ElasticsearchHarvester.java
@@ -34,11 +34,11 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
 import de.pangaea.metadataportal.config.HarvesterConfig;
 import de.pangaea.metadataportal.processor.DocumentProcessor;
 import de.pangaea.metadataportal.processor.ElasticsearchConnection;
+import de.pangaea.metadataportal.processor.MinimalTransportClient;
 import de.pangaea.metadataportal.utils.HostAndPort;
 
 /**
@@ -112,7 +112,7 @@ public class ElasticsearchHarvester extends SingleFileEntitiesHarvester {
       if (log.isDebugEnabled()) {
         log.debug("ES connection settings: " + settings.getAsMap());
       }
-      this.client = new PreBuiltTransportClient(settings).addTransportAddress(addr);
+      this.client = new MinimalTransportClient(settings).addTransportAddress(addr);
       this.closeClient = true;
     } else {
       log.info("Connecting to global Elasticsearch node for harvesting " + queryInfo + "...");

--- a/src/de/pangaea/metadataportal/harvester/Harvester.java
+++ b/src/de/pangaea/metadataportal/harvester/Harvester.java
@@ -112,7 +112,7 @@ public abstract class Harvester {
    * {@link Rebuilder}. Public code should use
    * {@link #runHarvester(Config,String)}.
    */
-  static boolean runHarvester(Config conf, String id, Class<? extends Harvester> harvesterClass) {
+  protected static boolean runHarvester(Config conf, String id, Class<? extends Harvester> harvesterClass) {
     final Set<String> activeIds;
     if (isAllIndexes(id)) {
       activeIds = conf.targetIndexes.keySet();
@@ -191,7 +191,7 @@ public abstract class Harvester {
     } 
   }
   
-  static boolean isAllIndexes(String id) {
+  protected static boolean isAllIndexes(String id) {
     return id == null || "*".equals(id) || "all".equals(id);
   }
   

--- a/src/de/pangaea/metadataportal/harvester/SingleFileEntitiesHarvester.java
+++ b/src/de/pangaea/metadataportal/harvester/SingleFileEntitiesHarvester.java
@@ -57,14 +57,21 @@ public abstract class SingleFileEntitiesHarvester extends Harvester {
   private Instant newestDatestamp = null;
   
   public SingleFileEntitiesHarvester(HarvesterConfig iconfig) {
+    this(iconfig, parseDocumentErrorAction(iconfig));
+  }
+  
+  protected SingleFileEntitiesHarvester(HarvesterConfig iconfig, DocumentErrorAction parseErrorAction) {
     super(iconfig);
+    this.parseErrorAction = parseErrorAction;
 
     if (BooleanParser.parseBoolean(iconfig.properties.getProperty(
         "deleteMissingDocuments", "true"))) validIdentifiers = new HashSet<>();
-
+  }
+  
+  private static DocumentErrorAction parseDocumentErrorAction(HarvesterConfig iconfig) {
     final String s = iconfig.properties.getProperty("parseErrorAction", DocumentErrorAction.IGNOREDOCUMENT.name());
     try {
-      parseErrorAction = DocumentErrorAction.valueOf(s.toUpperCase(Locale.ROOT));
+      return DocumentErrorAction.valueOf(s.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException("Invalid value '" + s
           + "' for harvester property 'parseErrorAction', valid ones are: "

--- a/src/de/pangaea/metadataportal/processor/ElasticsearchConnection.java
+++ b/src/de/pangaea/metadataportal/processor/ElasticsearchConnection.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
 import de.pangaea.metadataportal.config.Config;
 import de.pangaea.metadataportal.config.HarvesterConfig;
@@ -96,7 +95,7 @@ public final class ElasticsearchConnection implements Closeable {
       log.debug("ES connection settings: " + settings.getAsMap());
     }
     this.conf = config;
-    this.client = new PreBuiltTransportClient(settings)
+    this.client = new MinimalTransportClient(settings)
       .addTransportAddresses(config.esTransports.toArray(new TransportAddress[config.esTransports.size()]));
   }
 

--- a/src/de/pangaea/metadataportal/processor/MinimalTransportClient.java
+++ b/src/de/pangaea/metadataportal/processor/MinimalTransportClient.java
@@ -1,0 +1,106 @@
+package de.pangaea.metadataportal.processor;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.network.NetworkModule;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.transport.Netty4Plugin;
+
+import io.netty.util.ThreadDeathWatcher;
+import io.netty.util.concurrent.GlobalEventExecutor;
+
+public class MinimalTransportClient extends TransportClient {
+  static {
+    initializeNetty();
+  }
+  
+  /**
+   * Netty wants to do some unwelcome things like use unsafe and replace a private field, or use a poorly considered buffer recycler. This
+   * method disables these things by default, but can be overridden by setting the corresponding system properties.
+   */
+  private static void initializeNetty() {
+    /*
+     * We disable three pieces of Netty functionality here:
+     *  - we disable Netty from being unsafe
+     *  - we disable Netty from replacing the selector key set
+     *  - we disable Netty from using the recycler
+     *
+     * While permissions are needed to read and set these, the permissions needed here are innocuous and thus should simply be granted
+     * rather than us handling a security exception here.
+     */
+    setSystemPropertyIfUnset("io.netty.noUnsafe", Boolean.toString(true));
+    setSystemPropertyIfUnset("io.netty.noKeySetOptimization", Boolean.toString(true));
+    setSystemPropertyIfUnset("io.netty.recycler.maxCapacityPerThread", Integer.toString(0));
+  }
+  
+  private static void setSystemPropertyIfUnset(final String key, final String value) {
+    final String currentValue = System.getProperty(key);
+    if (currentValue == null) {
+      System.setProperty(key, value);
+    }
+  }
+  
+  private static final Collection<Class<? extends Plugin>> PRE_INSTALLED_PLUGINS =
+      Collections.unmodifiableList(Arrays.asList(
+          Netty4Plugin.class
+      ));
+  
+  /**
+   * Creates a new transport client with pre-installed plugins.
+   *
+   * @param settings the settings passed to this transport client
+   * @param plugins  an optional array of additional plugins to run with this client
+   */
+  @SafeVarargs
+  public MinimalTransportClient(Settings settings, Class<? extends Plugin>... plugins) {
+    this(settings, Arrays.asList(plugins));
+  }
+  
+  /**
+   * Creates a new transport client with pre-installed plugins.
+   *
+   * @param settings the settings passed to this transport client
+   * @param plugins  a collection of additional plugins to run with this client
+   */
+  public MinimalTransportClient(Settings settings, Collection<Class<? extends Plugin>> plugins) {
+    this(settings, plugins, null);
+  }
+  
+  /**
+   * Creates a new transport client with pre-installed plugins.
+   *
+   * @param settings            the settings passed to this transport client
+   * @param plugins             a collection of additional plugins to run with this client
+   * @param hostFailureListener a failure listener that is invoked if a node is disconnected; this can be <code>null</code>
+   */
+  public MinimalTransportClient(
+      Settings settings,
+      Collection<Class<? extends Plugin>> plugins,
+      HostFailureListener hostFailureListener) {
+    super(settings, Settings.EMPTY, addPlugins(plugins, PRE_INSTALLED_PLUGINS), hostFailureListener);
+  }
+    
+
+  @Override
+  public void close() {
+    super.close();
+    if (NetworkModule.TRANSPORT_TYPE_SETTING.exists(settings) == false
+        || NetworkModule.TRANSPORT_TYPE_SETTING.get(settings).equals(Netty4Plugin.NETTY_TRANSPORT_NAME)) {
+      try {
+        GlobalEventExecutor.INSTANCE.awaitInactivity(5, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      try {
+        ThreadDeathWatcher.awaitInactivity(5, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/src/de/pangaea/metadataportal/processor/MinimalTransportClient.java
+++ b/src/de/pangaea/metadataportal/processor/MinimalTransportClient.java
@@ -40,10 +40,10 @@ import io.netty.util.concurrent.GlobalEventExecutor;
  * This is a minimalistic {@link TransportClient} using Netty 4 only.
  * <p>
  * Pretty exact copy of {@code PreBuiltTransportClient} but only with
- * Netty 4 plugin dependency. {@link PreBuiltTransportClient} expects
+ * Netty 4 plugin dependency. {@code PreBuiltTransportClient} expects
  * both Netty 3 and Netty 4 to be present.
  *
- * @see https://github.com/elastic/elasticsearch/issues/31240
+ * @see <https://github.com/elastic/elasticsearch/issues/31240>
  **/
 public class MinimalTransportClient extends TransportClient {
   static {

--- a/src/de/pangaea/metadataportal/processor/MinimalTransportClient.java
+++ b/src/de/pangaea/metadataportal/processor/MinimalTransportClient.java
@@ -1,3 +1,25 @@
+/*
+ * Copy of the original PreBuiltTransportClient with
+ * modifications.
+ * 
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package de.pangaea.metadataportal.processor;
 
 import java.util.Arrays;
@@ -14,6 +36,15 @@ import org.elasticsearch.transport.Netty4Plugin;
 import io.netty.util.ThreadDeathWatcher;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
+/** 
+ * This is a minimalistic {@link TransportClient} using Netty 4 only.
+ * <p>
+ * Pretty exact copy of {@code PreBuiltTransportClient} but only with
+ * Netty 4 plugin dependency. {@link PreBuiltTransportClient} expects
+ * both Netty 3 and Netty 4 to be present.
+ *
+ * @see https://github.com/elastic/elasticsearch/issues/31240
+ **/
 public class MinimalTransportClient extends TransportClient {
   static {
     initializeNetty();
@@ -46,9 +77,7 @@ public class MinimalTransportClient extends TransportClient {
   }
   
   private static final Collection<Class<? extends Plugin>> PRE_INSTALLED_PLUGINS =
-      Collections.unmodifiableList(Arrays.asList(
-          Netty4Plugin.class
-      ));
+      Collections.singleton(Netty4Plugin.class);
   
   /**
    * Creates a new transport client with pre-installed plugins.
@@ -78,9 +107,7 @@ public class MinimalTransportClient extends TransportClient {
    * @param plugins             a collection of additional plugins to run with this client
    * @param hostFailureListener a failure listener that is invoked if a node is disconnected; this can be <code>null</code>
    */
-  public MinimalTransportClient(
-      Settings settings,
-      Collection<Class<? extends Plugin>> plugins,
+  public MinimalTransportClient(Settings settings, Collection<Class<? extends Plugin>> plugins,
       HostFailureListener hostFailureListener) {
     super(settings, Settings.EMPTY, addPlugins(plugins, PRE_INSTALLED_PLUGINS), hostFailureListener);
   }

--- a/src/de/pangaea/metadataportal/push/PushServer.java
+++ b/src/de/pangaea/metadataportal/push/PushServer.java
@@ -1,0 +1,148 @@
+package de.pangaea.metadataportal.push;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXSource;
+
+import org.xml.sax.InputSource;
+
+import de.pangaea.metadataportal.config.Config;
+import io.undertow.Handlers;
+import io.undertow.Undertow;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.DateUtils;
+import io.undertow.util.Headers;
+import io.undertow.util.PathTemplateMatch;
+import io.undertow.util.StatusCodes;
+
+/**
+ * TODO
+ * 
+ * @author Uwe Schindler
+ */
+public class PushServer {
+  
+  private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(PushServer.class);
+  
+  private final Config conf;
+  private final Map<String,PushWrapperHarvester> harvesters = new ConcurrentHashMap<>();
+  
+  private PushServer(Config conf) {
+    this.conf = conf;
+  }
+
+  public static void main(String... args) throws Exception {
+    if (args.length < 1 || args.length > 2) {
+      System.err.println("Command line: java " + PushServer.class.getName() + " config.xml");
+      return;
+    }
+    
+    try {
+      final Config conf = new Config(args[0]);
+      new PushServer(conf).runServer();
+    } catch (Exception e) {
+      log.fatal("PushServer general error:", e);
+    }
+  }
+  
+  private PushWrapperHarvester getHarvester(String id) {
+    return harvesters.computeIfAbsent(id, key -> PushWrapperHarvester.initializeWrapper(conf, key, h -> harvesters.remove(id)));
+  }
+  
+  private void runServer() {
+    final HttpHandler handler = Handlers.routing(false)
+        .put("/{harvester}/*", this::handlePut)
+        .delete("/{harvester}/*", this::handleDelete)
+        .post("/{harvester}/_commit", this::handleCommit);
+    Undertow.builder()
+      .addHttpListener(8089, "127.0.0.1")
+      .setHandler(handler)
+      .build()
+      .start();
+  }
+  
+  private void handlePut(HttpServerExchange e) {
+    if (e.isInIoThread()) {
+      e.dispatch(this::handlePut);
+      return;
+    }
+    e.startBlocking();
+    final Map<String,String> params = e.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+    final String harvester = params.get("harvester");
+    final String documentId = params.get("*");
+    final String lastModHdr = e.getRequestHeaders().getFirst(Headers.LAST_MODIFIED);
+    final Instant lastMod;
+    try {
+      lastMod = (lastModHdr == null) ? null : DateUtils.parseDate(lastModHdr).toInstant();
+    } catch (NullPointerException npe) {
+      log.error("Invald last modified date in HTTP request: " + lastModHdr);
+      e.setStatusCode(StatusCodes.BAD_REQUEST);
+      e.endExchange();
+      return;
+    }
+    try (InputStream in = e.getInputStream()) {
+      final InputSource saxSrc = new InputSource(in);
+      saxSrc.setSystemId(documentId);
+      saxSrc.setEncoding(e.getRequestCharset());
+      final Source src = new SAXSource(saxSrc);
+      log.info("Index object for harvester " + harvester + ": " + documentId);
+      getHarvester(harvester).addDocument(documentId, lastMod, src);
+      e.setStatusCode(StatusCodes.ACCEPTED);
+    } catch (Exception ex) {
+      log.error(ex);
+      e.setStatusCode(getStatusCode(ex));
+    }
+    e.endExchange();
+  }
+  
+  private void handleDelete(HttpServerExchange e) {
+    final Map<String,String> params = e.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+    final String harvester = params.get("harvester");
+    final String documentId = params.get("*");
+    log.info("Delete object for harvester " + harvester + ": " + documentId);
+    try {
+      getHarvester(harvester).deleteDocument(documentId);
+      e.setStatusCode(StatusCodes.ACCEPTED);
+    } catch (Exception ex) {
+      log.error(ex);
+      e.setStatusCode(getStatusCode(ex));
+    }
+    e.endExchange();
+  }
+  
+  private void handleCommit(HttpServerExchange e) {
+    final Map<String,String> params = e.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+    final String harvester = params.get("harvester");
+    if (PushWrapperHarvester.isValidHarvesterId(conf, harvester)) {
+      if (harvesters.containsKey(harvester)) {
+        log.info("Commit changes for harvester: " + harvester);
+        try {
+          getHarvester(harvester).commitAndClose();
+          e.setStatusCode(StatusCodes.NO_CONTENT);
+        } catch (Exception ex) {
+          log.error(ex);
+          e.setStatusCode(getStatusCode(ex));
+        }
+      } else {
+        log.info("Harvester not open, commit ignored: " + harvester);
+        e.setStatusCode(StatusCodes.NO_CONTENT);
+      }
+    } else {
+      e.setStatusCode(StatusCodes.NOT_FOUND);
+    }
+    e.endExchange();
+  }
+  
+  private int getStatusCode(Throwable e) {
+    if (e instanceof IllegalArgumentException) {
+      return StatusCodes.NOT_FOUND;
+    }
+    return StatusCodes.INTERNAL_SERVER_ERROR;
+  }
+  
+}

--- a/src/de/pangaea/metadataportal/push/PushWrapperHarvester.java
+++ b/src/de/pangaea/metadataportal/push/PushWrapperHarvester.java
@@ -1,0 +1,137 @@
+/*
+ *   Copyright panFMP Developers Team c/o Uwe Schindler
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package de.pangaea.metadataportal.push;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import javax.xml.transform.Source;
+
+import de.pangaea.metadataportal.config.Config;
+import de.pangaea.metadataportal.config.HarvesterConfig;
+import de.pangaea.metadataportal.harvester.Harvester;
+import de.pangaea.metadataportal.harvester.SingleFileEntitiesHarvester;
+import de.pangaea.metadataportal.processor.DocumentErrorAction;
+import de.pangaea.metadataportal.processor.ElasticsearchConnection;
+import de.pangaea.metadataportal.processor.MetadataDocument;
+
+public final class PushWrapperHarvester extends SingleFileEntitiesHarvester {
+  
+  private static final ThreadLocal<Consumer<PushWrapperHarvester>> STARTUP_CALLBACK_HOLDER = new ThreadLocal<>();
+  private static final ThreadLocal<Consumer<PushWrapperHarvester>> SHUTDOWN_CALLBACK_HOLDER = new ThreadLocal<>();
+  
+  public static boolean isValidHarvesterId(Config conf, String id) {
+    return !isAllIndexes(id) && conf.harvestersAndIndexes.contains(id) && !conf.targetIndexes.containsKey(id);
+  }
+  
+  public static PushWrapperHarvester initializeWrapper(Config conf, String id, Consumer<PushWrapperHarvester> shutdownCallback) {
+    if (!isValidHarvesterId(conf, id)) {
+      throw new IllegalArgumentException("Cannot find harvester name: " + id);
+    }
+    final CompletableFuture<PushWrapperHarvester> result = new CompletableFuture<>();
+    new Thread(() -> {
+      STARTUP_CALLBACK_HOLDER.set(result::complete);
+      SHUTDOWN_CALLBACK_HOLDER.set(shutdownCallback);
+      try {
+        runHarvester(conf, id, PushWrapperHarvester.class);
+      } catch (Exception e) {
+        result.completeExceptionally(e);
+      } finally {
+        STARTUP_CALLBACK_HOLDER.remove();
+        SHUTDOWN_CALLBACK_HOLDER.remove();
+      }
+    }, String.format(Locale.ROOT,"PushWrapperHarvester(%s)", id)).start();
+    return result.join();
+  }
+  
+  // harvester interface
+  private final Harvester wrappedHarvester;
+  private final long timeout = TimeUnit.SECONDS.toNanos(60);
+  private final AtomicLong lastAccessed = new AtomicLong(System.nanoTime());
+  private final CountDownLatch latch = new CountDownLatch(1);
+  
+  public PushWrapperHarvester(HarvesterConfig iconfig) throws Exception {
+    super(iconfig, DocumentErrorAction.STOP);
+    this.wrappedHarvester = iconfig.harvesterClass.getConstructor(HarvesterConfig.class).newInstance(iconfig);
+  }
+  
+  @Override
+  public void prepareReindex(ElasticsearchConnection es, String targetIndex) throws Exception {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public void finishReindex(boolean cleanShutdown) throws Exception {
+    throw new IllegalStateException();
+  }
+  
+  @Override
+  public MetadataDocument createMetadataDocumentInstance() {
+    return wrappedHarvester.createMetadataDocumentInstance();
+  }
+  
+  @Override
+  protected void enumerateValidHarvesterPropertyNames(Set<String> props) {
+    props.addAll(wrappedHarvester.getValidHarvesterPropertyNames());
+  }
+  
+  @Override
+  public void open(ElasticsearchConnection es, String targetIndex) throws Exception {
+    super.open(es, targetIndex);
+    cancelMissingDocumentDelete();
+  }
+
+  @Override
+  public void addDocument(String identifier, Instant lastModified, Source xml) throws Exception {
+    resetTimer();
+    super.addDocument(identifier, lastModified, xml);
+  }
+
+  @Override
+  public void deleteDocument(String identifier) throws Exception {
+    resetTimer();
+    super.deleteDocument(identifier);
+  }
+  
+  public void commitAndClose() throws Exception {
+    latch.countDown();
+  }
+
+  private void resetTimer() {
+    lastAccessed.set(System.nanoTime());
+  }
+
+  @Override
+  public void harvest() throws Exception {
+    cancelMissingDocumentDelete(); // be safe
+    
+    log.info("Waiting for push connections...");
+    STARTUP_CALLBACK_HOLDER.get().accept(this);
+    while (latch.getCount() > 0L && System.nanoTime() - lastAccessed.get() < timeout) {
+      latch.await(1, TimeUnit.SECONDS);
+    }
+    SHUTDOWN_CALLBACK_HOLDER.get().accept(this);
+    log.info("Shutting down push mode...");
+  }
+  
+}


### PR DESCRIPTION
This adds initial support for a small service (based on *undertow* NIO based webserver) to directly push documents to the index by using the harvester's configuration (including all transformations & checks). This is basically an invocation on the underlying harvester's addDocument() or deleteDocument().

This is still WIP, but its functionable.

As a side effect, the dependencies of panFMP were cleaned up. The TransportClient no longer uses any plugins and only the Netty4 transport, so many transitive dependencies were removed (14!).